### PR TITLE
Add unit tests for RuleEngine using MockK and update rule configurations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
   testImplementation("org.springframework.modulith:spring-modulith-starter-test")
   testImplementation("org.testcontainers:junit-jupiter")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+  testImplementation("io.mockk:mockk:1.13.7")
 }
 
 dependencyManagement {

--- a/src/main/kotlin/trile/rule/engine/RuleSetWrapper.kt
+++ b/src/main/kotlin/trile/rule/engine/RuleSetWrapper.kt
@@ -1,10 +1,7 @@
 package trile.rule.engine
 
-import trile.common.getOrThrow
 import trile.rule.action.Action
 import trile.rule.condition.Condition
-import trile.rule.condition.ConditionType
-import trile.rule.model.ConditionDefinition
 
 data class RuleSetWrapper<C, A>(
   val conditions: List<ConditionWithParameter<C>>,

--- a/src/test/kotlin/trile/rule/engine/RuleEngineTest.kt
+++ b/src/test/kotlin/trile/rule/engine/RuleEngineTest.kt
@@ -1,0 +1,98 @@
+package trile.rule.engine
+
+import io.mockk.spyk
+import io.mockk.verify
+import java.math.BigDecimal
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import trile.rule.action.Action
+import trile.rule.action.ActionType
+import trile.rule.condition.Condition
+import trile.rule.condition.ConditionType
+import trile.rule.model.RuleConfiguration
+import trile.rule.model.TransactionContext
+
+@SpringBootTest
+class RuleEngineTest {
+
+  private lateinit var ruleEngine: RuleEngine
+
+  @Autowired
+  private lateinit var conditionMap: Map<ConditionType, Condition<Any>>
+
+  @Autowired
+  private lateinit var actionMap: Map<ActionType, Action<Any>>
+
+  @Autowired
+  private lateinit var ruleConfig: RuleConfiguration
+
+  private lateinit var spyConditionMap: Map<ConditionType, Condition<Any>>
+  private lateinit var spyActionMap: Map<ActionType, Action<Any>>
+
+  @BeforeEach
+  fun setup() {
+    spyConditionMap = conditionMap.mapValues { spyk(it.value) }
+    spyActionMap = actionMap.mapValues { spyk(it.value) }
+    ruleEngine = RuleEngine(ruleConfig, spyConditionMap, spyActionMap)
+  }
+
+  @Test
+  fun `should execute multiple actions for regular card when conditions match`() {
+    val context = TransactionContext(type = "regular-card", amount = 10000.toBigDecimal())
+
+    ruleEngine.executeRules(context)
+
+    verify {
+      spyActionMap[ActionType.EARN_POINT_BY_RATE]!!.execute(context, 0.02.toBigDecimal())
+      spyActionMap[ActionType.EARN_POINT_BY_RATE]!!.execute(context, 0.05.toBigDecimal())
+    }
+  }
+
+  @Test
+  fun `should execute actions for super card when any condition matches`() {
+    val context1 = TransactionContext(type = "super-card", amount = 10000.toBigDecimal())
+    val context2 = TransactionContext(type = "super-card", amount = 10001.toBigDecimal())
+
+    ruleEngine.executeRules(context1)
+    ruleEngine.executeRules(context2)
+
+    verify(exactly = 2) {
+      spyActionMap[ActionType.EARN_POINT_BY_RATE]!!.execute(any(), 0.1.toBigDecimal())
+    }
+  }
+
+  @Test
+  fun `should not execute actions when conditions fail`() {
+    val context = TransactionContext(type = "regular-card", amount = 5000.toBigDecimal())
+
+    ruleEngine.executeRules(context)
+
+    verify(exactly = 0) {
+      spyActionMap[ActionType.EARN_POINT_BY_RATE]!!.execute(any(), any(BigDecimal::class))
+    }
+  }
+
+  @Test
+  fun `should execute actions for online card with not equals condition`() {
+    val context = TransactionContext(type = "online-card", amount = 10000.toBigDecimal())
+
+    ruleEngine.executeRules(context)
+
+    verify {
+      spyActionMap[ActionType.EARN_POINT_BY_RATE]!!.execute(context, 0.04.toBigDecimal())
+    }
+  }
+
+  @Test
+  fun `should skip execution if executor is not found`() {
+    val context = TransactionContext(type = "unknown-card", amount = 10000.toBigDecimal())
+
+    ruleEngine.executeRules(context)
+
+    verify(exactly = 0) {
+      spyActionMap[ActionType.EARN_POINT_BY_RATE]!!.execute(any(), any(BigDecimal::class))
+    }
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,50 @@
+rules:
+  use-cases:
+    regular-card:
+      name: Regular Card Purchases
+      rules:
+        - name: Earn points for regular card purchases with a minimum spend of 10,000 VND
+          conditions:
+            - type: EQUALS
+              parameters:
+                amount: 10000
+          actions:
+            - type: EARN_POINT_BY_RATE
+              parameters:
+                rate: 0.02 # 2% reward rate for eligible transactions
+            - type: EARN_POINT_BY_RATE
+              parameters:
+                rate: 0.05 # Additional 5% reward rate for specific transactions
+
+    super-card:
+      name: Super Card Purchases
+      rules:
+        - name: Earn points for super card purchases of 10,000 or 10,001 VND
+          conditions:
+            - type: OPERATOR
+              or:
+                - type: EQUALS
+                  parameters:
+                    amount: 10000
+                - type: EQUALS
+                  parameters:
+                    amount: 10001
+          actions:
+            - type: EARN_POINT_BY_RATE
+              parameters:
+                rate: 0.1 # 10% reward rate for super card transactions
+
+    online-card:
+      name: Online Card Purchases
+      rules:
+        - name: Earn points for online purchases not equal to 1 VND
+          conditions:
+            - type: OPERATOR
+              not:
+                - type: EQUALS
+                  parameters:
+                    amount: 1
+          actions:
+            - type: EARN_POINT_BY_RATE
+              parameters:
+                rate: 0.04 # 4% reward rate for online purchases


### PR DESCRIPTION
- Add `io.mockk:mockk:1.13.7` to dependencies for mocking capabilities.
- Implement `RuleEngineTest` with test cases to verify rule execution logic.
- Use `spyk` to create spies for condition and action maps.
- Add test cases to verify actions executed based on transaction context.
- Update rule configurations to include detailed conditions and actions for different card types.
- Remove unused imports and clean up configuration files.